### PR TITLE
Removed compost bucket from todo list

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,4 @@ Plugin which deplays the contents of compost bins and the amount of compost rema
 
 ### Todo list:
 * Add remaining rotting timer to compost bin overlay
-* Bottomless compost bucket charges tracking
 * Reminder to add compost to patches


### PR DESCRIPTION
Fixes #1. Already supported by item charges plugin.